### PR TITLE
Fix Python 3 issue.

### DIFF
--- a/shakespearelang/shakespeare_interpreter.py
+++ b/shakespearelang/shakespeare_interpreter.py
@@ -163,9 +163,9 @@ class Shakespeare:
                      character asking the question.
         """
         question = self._parse_if_necessary(question, 'question')
-        values = map(self.evaluate_expression,
-                     [question.first_value, question.second_value]
-                     )
+        values = [self.evaluate_expression(question.first_value, character), 
+                     self.evaluate_expression(question.second_value, character)
+                    ]
         if question.comparative.parseinfo.rule == 'positive_comparative':
             return values[0] > values[1]
         elif question.comparative.parseinfo.rule == 'negative_comparative':


### PR DESCRIPTION
Hi there! 
I don't know if you're still maintaining this, and I also know basically no Python, but I was attempting to use the interpreter and found that it attempted to iterate over a list in `evaluate_question`, which apparently isn't allowed in Python 3. This is a fix for that, but it is pretty inelegant.

Thanks!