### PR TITLE
Add try block to import readline

### DIFF
--- a/shakespearelang/_repl.py
+++ b/shakespearelang/_repl.py
@@ -3,7 +3,11 @@ from .errors import ShakespeareError
 from ._utils import normalize_name
 from tatsu.exceptions import FailedParse
 
-import readline
+try:
+    import readline
+except ModuleNotFoundError:
+  print("readline module is not supported in Windows, continuing without it.")
+
 import sys
 
 

--- a/shakespearelang/_repl.py
+++ b/shakespearelang/_repl.py
@@ -6,7 +6,7 @@ from tatsu.exceptions import FailedParse
 try:
     import readline
 except ModuleNotFoundError:
-  print("readline module is not supported in Windows, continuing without it.")
+    print("readline module is not supported in Windows, continuing without it.")
 
 import sys
 


### PR DESCRIPTION
Add a try block to import readline to improve windows compatibility.

**Testing**
Executing a [Hello World .spl file](https://github.com/stuart-thomas-zoopla/Hello-EsoLangs/blob/main/Shakespeare/Hello.spl) in windows 11.

Before fix
![image](https://github.com/zmbc/shakespearelang/assets/77386766/de3cd90d-f5fb-4d68-91d1-85447eab259b)

After fix
![image](https://github.com/zmbc/shakespearelang/assets/77386766/02452c80-28a3-4305-8bd5-9e29f0b90330)
